### PR TITLE
Fix ValidatorTrait

### DIFF
--- a/app/Traits/ValidatorTrait.php
+++ b/app/Traits/ValidatorTrait.php
@@ -119,7 +119,7 @@ trait ValidatorTrait
             return null;
         }
 
-        return $xpath->query('/md:EntityDescriptor/md:IDPSSODescriptor/md:Extensions/shibmd:Scope')->item(0)->nodeValue;
+        return $xpath->query('/md:EntityDescriptor/md:IDPSSODescriptor/md:Extensions/shibmd:Scope')->item(0)->nodeValue ?? null;
     }
 
     public function getEntityFile(object $xpath): string


### PR DESCRIPTION
getEntityScope function now returns Scope of the entity or null in case Scope is missing in metadata.