### PR TITLE
Allow previewing metadata

### DIFF
--- a/app/Http/Controllers/EntityPreviewMetadataController.php
+++ b/app/Http/Controllers/EntityPreviewMetadataController.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Entity;
+
+class EntityPreviewMetadataController extends Controller
+{
+    public function __construct()
+    {
+        $this->middleware('auth');
+    }
+
+    public function show(Entity $entity)
+    {
+        $this->authorize('view', $entity);
+
+        return response($entity->metadata, 200)
+            ->header('Content-Type', 'application/xml');
+    }
+}

--- a/resources/views/entities/show.blade.php
+++ b/resources/views/entities/show.blade.php
@@ -149,10 +149,14 @@
                 <a class="hover:bg-blue-700 text-blue-50 inline-block px-4 py-2 bg-blue-600 rounded shadow"
                     href="{{ route('entities.showmetadata', $entity) }}"
                     target="_blank">{{ __('entities.show_metadata') }}</a>
+            @else
+                <a class="hover:bg-blue-700 text-blue-50 inline-block px-4 py-2 bg-blue-600 rounded shadow"
+                    href="{{ route('entities.previewmetadata', $entity) }}"
+                    target="_blank">{{ __('entities.show_metadata') }}</a>
             @endif
 
             @can('update', $entity)
-                @unless($entity->trashed())
+                @unless ($entity->trashed())
                     <a class="hover:bg-yellow-200 inline-block px-4 py-2 text-yellow-600 bg-yellow-300 rounded shadow"
                         href="{{ route('entities.edit', $entity) }}">{{ __('common.edit') }}</a>
                 @endunless

--- a/routes/web.php
+++ b/routes/web.php
@@ -10,6 +10,7 @@ use App\Http\Controllers\EntityManagementController;
 use App\Http\Controllers\EntityMetadataController;
 use App\Http\Controllers\EntityOperatorController;
 use App\Http\Controllers\EntityOrganizationController;
+use App\Http\Controllers\EntityPreviewMetadataController;
 use App\Http\Controllers\EntityRsController;
 use App\Http\Controllers\FakeController;
 use App\Http\Controllers\FederationController;
@@ -89,6 +90,7 @@ Route::post('entities/{entity}/rs', [EntityRsController::class, 'store'])->name(
 
 Route::get('entities/{entity}/metadata', [EntityMetadataController::class, 'store'])->name('entities.metadata');
 Route::get('entities/{entity}/showmetadata', [EntityMetadataController::class, 'show'])->name('entities.showmetadata');
+Route::get('entities/{entity}/previewmetadata', [EntityPreviewMetadataController::class, 'show'])->name('entities.previewmetadata');
 
 Route::post('entities/{entity}/organization', [EntityOrganizationController::class, 'update'])->name('entities.organization');
 


### PR DESCRIPTION
Metadata download is taken from the Git repository, however, metadata pending approval isn't stored in the Git repository yet and thus must be taken from the database instead.