### PR TITLE
Fix EntityController.php

### DIFF
--- a/app/Http/Controllers/EntityController.php
+++ b/app/Http/Controllers/EntityController.php
@@ -573,7 +573,9 @@ class EntityController extends Controller
         if (! app()->environment('testing')) {
             if ($entity->type->value === 'idp' && ! $entity->hfd) {
                 $eduidczOrganization = EduidczOrganization::whereEntityIDofIdP($entity->entityid)->first();
-                $eduidczOrganization->delete();
+                if (!is_null($eduidczOrganization)) {
+                    $eduidczOrganization->delete();
+                }
             }
         }
 


### PR DESCRIPTION
In case that IdP isn't a member of eduID.cz, it's not tied to any EduidczOrganization within LDAP (for example an IdP of Standalone federation). This fix skips trying to delete non existent LDAP entry.